### PR TITLE
Key catch and Tree.getByPath fixes

### DIFF
--- a/src/js/core/Tree.js
+++ b/src/js/core/Tree.js
@@ -95,12 +95,42 @@ Tree.prototype.findById = function ( id ) {
 
 };
 
+/*
 Tree.prototype.getByPath = function ( path ) {
 
 	const pathArray = path.split( '.' );
 	const node = this.getByPathArray( pathArray );
 
 	return ( pathArray.length === 0 ) ? node: undefined;
+
+};
+*/
+
+Tree.prototype.getByPath = function ( path ) {
+
+	if (!path)
+		return undefined;
+
+	const pathArray = path.split( '.' );
+
+	let node = this.getByPathArray( pathArray );
+
+	let pathArrayPos = undefined;
+
+	if (pathArray.length !== 0)
+	{
+		const pathArrayEx = path.split( '.' );
+
+		if (pathArrayEx.length - 2 < 0)
+			return undefined;
+
+		var pathArrayMainPath = pathArrayEx.slice(0, pathArrayEx.length - 2);
+		var pathPosStation = pathArrayEx.slice(pathArrayEx.length - 2, pathArrayEx.length).join( '.' );
+
+		node = this.getByPathArray( pathArrayPos = pathArrayMainPath.concat(pathPosStation) );
+	}
+
+	return ( (pathArray.length === 0) || (pathArrayPos.length === 0) ) ? node: undefined;
 
 };
 

--- a/src/js/ui/KeyboardControls.js
+++ b/src/js/ui/KeyboardControls.js
@@ -13,9 +13,11 @@ function KeyboardControls ( viewer, fileSelector, avenControls ) {
 
 	function keyDown ( event ) {
 
-		event.preventDefault();
+		// event.preventDefault();
 
 		if ( ! viewer.surveyLoaded || ! viewer.mouseOver ) return;
+
+		event.preventDefault(); // enables F5, ctrl+<F5>, ctrl+<F> and other keys on the control's host page
 
 		if ( handleKeyCommon( event ) ) return;
 


### PR DESCRIPTION
1. [3ed6dd3](https://github.com/aardgoose/CaveView.js/commit/3ed6dd31a282ded0918482d76837398d239e077f)
CaveView.js disable the browser shortcut keys and key combinations. On trying to refresh the page or search in page (using F5, ctrl+<F5>, ctrl+<F>), it doesn't work because the CaveView control catches all those keys. This changes this behaviour by reenabling the keys on the control's host page.

2. [a6ea062](https://github.com/aardgoose/CaveView.js/commit/a6ea06278832ea8320e22fcd7dbe45e32ac7bf14)
Sometimes the station names contain the "." character. **Tree.getByPath** function doesn't work in those cases returning undefined . The new version works around this issue.